### PR TITLE
AWS Access Key Validation tweak

### DIFF
--- a/lib/awskeyring/validate.rb
+++ b/lib/awskeyring/validate.rb
@@ -20,7 +20,7 @@ module Awskeyring
     #
     # @param [String] aws_access_key The aws_access_key_id
     def self.access_key(aws_access_key)
-      raise 'Invalid Access Key' unless /\AAKIA[A-Z0-9]{12,16}\z/.match?(aws_access_key)
+      raise 'Invalid Access Key' unless /\AAKIA[A-Z234567]{16}\z/.match?(aws_access_key)
 
       aws_access_key
     end

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -45,7 +45,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   # print the version number
   def __version
     puts "Awskeyring v#{Awskeyring::VERSION}"
-    if !options['no-remote'] && Awskeyring::VERSION != Awskeyring.latest_version
+    if !options['no-remote'] && Awskeyring.latest_version != Awskeyring::VERSION
       puts "the latest version v#{Awskeyring.latest_version}"
     end
     puts "Homepage #{Awskeyring::HOMEPAGE}"

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "December 2022" "" ""
+.TH "AWSKEYRING" "5" "January 2023" "" ""
 .
 .SH "NAME"
 \fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain

--- a/spec/lib/awskeyring/validate_spec.rb
+++ b/spec/lib/awskeyring/validate_spec.rb
@@ -15,7 +15,7 @@ describe Awskeyring::Validate do
     let(:test_broken_secret) { 'hI7XqAiaR_XJxKgCqG0Wo79jm2+GcRYP' }
     let(:test_secret) { 'vbkEXAMPLEa3TlCP2Fvmcbdp83LSaeDHtx13xc+M' }
     let(:test_broken_key) { 'AKIA1234567890' }
-    let(:test_key) { 'AKIA1234567890ABCDEF' }
+    let(:test_key) { 'AKIA234567ABCDEFGHIJ' }
 
     it 'validates an account name' do
       expect { validate.account_name(test_account) }.not_to raise_error

--- a/spec/lib/awskeyring_command_more_spec.rb
+++ b/spec/lib/awskeyring_command_more_spec.rb
@@ -258,7 +258,7 @@ describe AwskeyringCommand do
   end
 
   context 'when we try to add an AWS account' do
-    let(:access_key) { 'AKIA0123456789ABCDEF' }
+    let(:access_key) { 'AKIA234567ABCDEFGHIJ' }
     let(:secret_access_key) { 'AbCkTEsTAAAi8ni0987ASDFwer23j14FEQW3IUJV' }
     let(:mfa_arn) { 'arn:aws:iam::012345678901:mfa/readonly' }
     let(:bad_access_key) { 'akIA01_678F' }
@@ -351,7 +351,7 @@ describe AwskeyringCommand do
   end
 
   context 'when we try to add an AWS account and test an mfa' do
-    let(:access_key) { 'AKIA0123456789ABCDEF' }
+    let(:access_key) { 'AKIA234567ABCDEFGHIJ' }
     let(:secret_access_key) { 'AbCkTEsTAAAi8ni0987ASDFwer23j14FEQW3IUJV' }
     let(:mfa_arn) { 'arn:aws:iam::012345678901:mfa/readonly' }
     let(:bad_mfa_arn) { 'arn:azure:iamnot::ABCD45678901:Administrators' }

--- a/spec/lib/awskeyring_spec.rb
+++ b/spec/lib/awskeyring_spec.rb
@@ -215,7 +215,7 @@ describe Awskeyring do
   end
 
   context 'when there is accounts and roles and tokens' do
-    let(:access_key) { 'AKIA1234567890ABCDEF' }
+    let(:access_key) { 'AKIA234567ABCDEFGHIJ' }
     let(:role_arn) { 'arn:aws:iam::012345678901:role/test' }
     let(:item) do
       instance_double(


### PR DESCRIPTION
# Description

Updates the (offline) validation of the AWS Access Keys to be stricter. This will affect any test keys a person generates or non AWS S3 compatible systems (eg. Minio). 

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
