### PR TITLE
Decode Account IDs from access keys.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,25 +6,30 @@
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
 name: Ruby
-
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
-
+    branches: ["main"]
 permissions:
   contents: read
-
 jobs:
   test:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.6.10
-        bundler-cache: true
-    - name: Run tests
-      run: bundle exec rake
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6.10
+          bundler-cache: true
+      - name: Run filemode
+        run: bundle exec rake filemode
+      - name: Run Rubocop
+        run: bundle exec rake rubocop
+      - name: Run Rspec
+        run: bundle exec rake spec
+      - name: Run Ronn Doc
+        run: bundle exec rake ronn
+      - name: Run Yard Doc
+        run: bundle exec rake yard

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -5,6 +5,7 @@ en:
   add_role_desc: Adds a ROLE to the keyring
   awskeyring_desc: Autocompletion for bourne shells
   console_desc: Open the AWS Console for the ACCOUNT
+  decode_desc: Decode an account id from a KEY
   default_desc: Run default help or initialise if needed.
   env_desc: Outputs bourne shell environment exports for an ACCOUNT
   exec_desc: Execute a COMMAND with the environment set for an ACCOUNT

--- a/lib/awskeyring.rb
+++ b/lib/awskeyring.rb
@@ -4,6 +4,7 @@ require 'i18n'
 require 'json'
 require 'keychain'
 require 'awskeyring/validate'
+require 'awskeyring/awsapi'
 
 # Awskeyring Module,
 # gives you an interface to access keychains and items.
@@ -193,6 +194,19 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
     tokens = list_tokens.map { |elem| elem.attributes[:label][(SESSION_KEY_PREFIX.length)..] }
 
     (items + tokens).uniq.sort
+  end
+
+  # Return a list account item names plus account ids
+  def self.list_account_names_plus # rubocop:disable Metrics/AbcSize
+    list_items.concat(list_tokens).map do |elem|
+      account_id = Awskeyring::Awsapi.get_account_id(key: elem.attributes[:account])
+      account_name = if elem.attributes[:label].start_with?(ACCOUNT_PREFIX)
+                       elem.attributes[:label][(ACCOUNT_PREFIX.length)..]
+                     else
+                       elem.attributes[:label][(SESSION_KEY_PREFIX.length)..]
+                     end
+      "#{account_name}\t#{account_id}"
+    end.uniq.sort
   end
 
   # Return a list role item names

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "September 2023" "" ""
+.TH "AWSKEYRING" "5" "October 2023" "" ""
 .
 .SH "NAME"
 \fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain
@@ -158,6 +158,9 @@ list:
 .
 .IP
 Prints a list of accounts in the keyring
+.
+.IP
+\-d, \-\-detail, \-\-no\-detail: Show more detail\.
 .
 .TP
 list\-role:

--- a/man/awskeyring.5.ronn
+++ b/man/awskeyring.5.ronn
@@ -86,6 +86,8 @@ The commands are as follows:
 
     Prints a list of accounts in the keyring
 
+    -d, --detail, --no-detail: Show more detail.
+
 * list-role:
 
     Prints a list of roles in the keyring<br>

--- a/spec/lib/awskeyring/awsapi_spec.rb
+++ b/spec/lib/awskeyring/awsapi_spec.rb
@@ -40,7 +40,7 @@ describe Awskeyring::Awsapi do
         instance_double(
           Aws::STS::Types::AssumeRoleResponse,
           assumed_role_user: {
-            arn: 'arn:aws:sts::123456789012:assumed-role/demo/Bob',
+            arn: 'arn:aws:sts::747118721026:assumed-role/demo/Bob',
             assumed_role_id: 'ARO123EXAMPLE123:Bob'
           },
           credentials: {
@@ -62,7 +62,7 @@ describe Awskeyring::Awsapi do
         instance_double(
           Aws::STS::Types::AssumeRoleResponse,
           assumed_role_user: {
-            arn: 'arn:aws:sts::123456789012:assumed-role/demo/Bob',
+            arn: 'arn:aws:sts::747118721026:assumed-role/demo/Bob',
             assumed_role_id: 'ARO123EXAMPLE123:Bob'
           },
           credentials: {
@@ -217,7 +217,7 @@ describe Awskeyring::Awsapi do
   end
 
   context 'when credentials are verified' do
-    let(:key) { 'AKIA1234567890ABCDEF' }
+    let(:key) { 'AKIA234567ABCDEFGHIJ' }
     let(:secret) { 'AbCkTEsTAAAi8ni0987ASDFwer23j14FEQW3IUJV' }
     let(:token) { 'AQoDYXdzEPT//////////wEXAMPLEtc764assume_roleDOk4x4HIZ8j4FZTwdQWLWsKWHGBuFqwAeMi' }
 
@@ -227,9 +227,9 @@ describe Awskeyring::Awsapi do
       allow(described_class).to receive(:region).and_return(nil)
       allow(Aws::STS::Client).to receive(:new).and_return(sts_client)
       allow(sts_client).to receive(:get_caller_identity).and_return(
-        account: '123456789012',
-        arn: 'arn:aws:iam::123456789012:user/Alice',
-        user_id: 'AKIAI44QH8DHBEXAMPLE'
+        account: '747118721026',
+        arn: 'arn:aws:iam::747118721026:user/Alice',
+        user_id: 'AKIA234567ABCDEFGHIJ'
       )
     end
 
@@ -240,11 +240,19 @@ describe Awskeyring::Awsapi do
     it 'calls get_caller_identity with a token' do
       expect(awsapi.verify_cred(key: key, secret: secret, token: token)).to be(true)
     end
+
+    it 'calls get_account_id with a valid token' do
+      expect(awsapi.get_account_id(key: key)).to eq('747118721026')
+    end
+
+    it 'calls get_account_id returning a short account number' do
+      expect(awsapi.get_account_id(key: 'AKIAQAAA67ABCDEFGHIJ')).to eq('000002029570')
+    end
   end
 
   context 'when keys are roated' do
     let(:account) { 'test' }
-    let(:key) { 'AKIA1234567890ABCDEF' }
+    let(:key) { 'AKIA234567ABCDEFGHIJ' }
     let(:secret) { 'AbCkTEsTAAAi8ni0987ASDFwer23j14FEQW3IUJV' }
     let(:new_key) { 'AKIAIOSFODNN7EXAMPLE' }
     let(:new_secret) { 'wJalrXUtnFEMI/K7MDENG/bPxRiCYzEXAMPLEKEY' }
@@ -258,7 +266,7 @@ describe Awskeyring::Awsapi do
       allow(iam_client).to receive_messages(
         list_access_keys: { access_key_metadata: [
           {
-            access_key_id: 'AKIATESTTEST',
+            access_key_id: 'AKIA234567ABCDEFGHIJ',
             create_date: Time.parse('2016-12-01T22:19:58Z'),
             status: 'Active',
             user_name: 'Alice'
@@ -293,7 +301,7 @@ describe Awskeyring::Awsapi do
 
   context 'when key rotation fails' do
     let(:account) { 'test' }
-    let(:key) { 'AKIA1234567890ABCDEF' }
+    let(:key) { 'AKIA234567ABCDEFGHIJ' }
     let(:secret) { 'AbCkTEsTAAAi8ni0987ASDFwer23j14FEQW3IUJV' }
     let(:key_message) { '# You have two access keys for account test' }
     let(:iam_client) { instance_double(Aws::IAM::Client) }
@@ -333,7 +341,7 @@ describe Awskeyring::Awsapi do
 
   context 'when key rotation fails to delete' do
     let(:account) { 'test' }
-    let(:key) { 'AKIA1234567890ABCDEF' }
+    let(:key) { 'AKIA234567ABCDEFGHIJ' }
     let(:secret) { 'AbCkTEsTAAAi8ni0987ASDFwer23j14FEQW3IUJV' }
     let(:new_key) { 'AKIAIOSFODNN7EXAMPLE' }
     let(:new_secret) { 'wJalrXUtnFEMI/K7MDENG/bPxRiCYzEXAMPLEKEY' }
@@ -402,13 +410,14 @@ describe Awskeyring::Awsapi do
       expect(awsapi.get_env_array(
                account: 'test',
                expiry: 1_489_305_329,
-               key: 'ASIAIOSFODNN7EXAMPLE',
+               key: 'ASIA234567ABCDEFGHIJ',
                secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',
                token: role_token
              )).to eq(
-               'AWS_ACCESS_KEY' => 'ASIAIOSFODNN7EXAMPLE',
-               'AWS_ACCESS_KEY_ID' => 'ASIAIOSFODNN7EXAMPLE',
+               'AWS_ACCESS_KEY' => 'ASIA234567ABCDEFGHIJ',
+               'AWS_ACCESS_KEY_ID' => 'ASIA234567ABCDEFGHIJ',
                'AWS_ACCOUNT_NAME' => 'test',
+               'AWS_ACCOUNT_ID' => '747118721026',
                'AWS_CREDENTIAL_EXPIRATION' => Time.at(1_489_305_329).iso8601,
                'AWS_DEFAULT_REGION' => 'us-east-1',
                'AWS_SECRET_ACCESS_KEY' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',
@@ -420,7 +429,7 @@ describe Awskeyring::Awsapi do
   end
 
   context 'when existing creds are loaded from a file' do
-    let(:key) { 'AKIA1234567890ABCDEF' }
+    let(:key) { 'AKIA234567ABCDEFGHIJ' }
     let(:secret) { 'AbCkTEsTAAAi8ni0987ASDFwer23j14FEQW3IUJV' }
     let(:token) { 'AQoDYXdzEPT//////////wEXAMPLEtc764assume_roleDOk4x4HIZ8j4FZTwdQWLWsKWHGBuFqwAeMi' }
     let(:account_key) { 'AKIAIOSFODNN7EXAMPLE' }
@@ -522,6 +531,10 @@ describe Awskeyring::Awsapi do
           user: 'rspec-user'
         )
       end.to raise_error(SystemExit).and output(/The security token included in the request is invalid/).to_stderr
+    end
+
+    it 'calls get_account_id with an invalid token' do
+      expect(awsapi.get_account_id(key: key)).to eq('000000000000')
     end
   end
 end

--- a/spec/lib/awskeyring_command_exceptional_spec.rb
+++ b/spec/lib/awskeyring_command_exceptional_spec.rb
@@ -14,7 +14,7 @@ describe AwskeyringCommand do
       allow(Awskeyring::Awsapi).to receive(:region).and_return(nil)
       allow(Awskeyring).to receive_messages(
         get_valid_creds: { account: 'test',
-                           key: 'ASIATESTTEST',
+                           key: 'AKIA234567ABCDEFGHIJ',
                            secret: 'bigerlongbase64',
                            token: nil,
                            updated: Time.parse('2011-08-01T22:20:01Z') },
@@ -89,8 +89,9 @@ describe AwskeyringCommand do
       expect { described_class.start(%w[env test --force]) }
         .to output(%(export AWS_DEFAULT_REGION="us-east-1"
 export AWS_ACCOUNT_NAME="test"
-export AWS_ACCESS_KEY_ID="ASIATESTTEST"
-export AWS_ACCESS_KEY="ASIATESTTEST"
+export AWS_ACCOUNT_ID="747118721026"
+export AWS_ACCESS_KEY_ID="AKIA234567ABCDEFGHIJ"
+export AWS_ACCESS_KEY="AKIA234567ABCDEFGHIJ"
 export AWS_SECRET_ACCESS_KEY="bigerlongbase64"
 export AWS_SECRET_KEY="bigerlongbase64"
 unset AWS_CREDENTIAL_EXPIRATION

--- a/spec/lib/awskeyring_spec.rb
+++ b/spec/lib/awskeyring_spec.rb
@@ -84,9 +84,9 @@ describe Awskeyring do
         Keychain::Item,
         attributes: {
           label: 'account test',
-          account: 'AKIATESTTEST',
+          account: 'AKIA234567ABCDEFGHIJ',
           updated_at: Time.parse('2016-12-01T22:20:01Z'),
-          comment: 'arn:aws:iam::012345678901:mfa/ec2-user'
+          comment: 'arn:aws:iam::747118721026:mfa/ec2-user'
         },
         password: 'biglongbase64'
       )
@@ -94,14 +94,14 @@ describe Awskeyring do
     let(:role) do
       instance_double(
         Keychain::Item,
-        attributes: { label: 'role test', account: 'arn:aws:iam::012345678901:role/test' },
+        attributes: { label: 'role test', account: 'arn:aws:iam::747118721026:role/test' },
         password: ''
       )
     end
     let(:roleee) do
       instance_double(
         Keychain::Item,
-        attributes: { label: 'role testee', account: 'arn:aws:iam::012345678901:role/testee' },
+        attributes: { label: 'role testee', account: 'arn:aws:iam::747118721026:role/testee' },
         password: ''
       )
     end
@@ -131,11 +131,11 @@ describe Awskeyring do
     it 'returns a hash with the creds' do
       expect(awskeyring.get_valid_creds(account: 'test', no_token: true)).to eq(
         account: 'test',
-        key: 'AKIATESTTEST',
+        key: 'AKIA234567ABCDEFGHIJ',
         secret: 'biglongbase64',
         token: nil,
         expiry: nil,
-        mfa: 'arn:aws:iam::012345678901:mfa/ec2-user',
+        mfa: 'arn:aws:iam::747118721026:mfa/ec2-user',
         updated: Time.parse('2016-12-01T22:20:01Z')
       )
     end
@@ -197,7 +197,7 @@ describe Awskeyring do
 
     it 'returns a hash with the role' do
       expect(awskeyring.get_role_arn(role_name: 'test')).to eq(
-        'arn:aws:iam::012345678901:role/test'
+        'arn:aws:iam::747118721026:role/test'
       )
     end
 
@@ -215,14 +215,14 @@ describe Awskeyring do
 
   context 'when there is accounts and roles and tokens' do
     let(:access_key) { 'AKIA234567ABCDEFGHIJ' }
-    let(:role_arn) { 'arn:aws:iam::012345678901:role/test' }
+    let(:role_arn) { 'arn:aws:iam::747118721026:role/test' }
     let(:item) do
       instance_double(
         Keychain::Item,
         attributes: {
           label: 'account test',
           account: access_key,
-          comment: 'arn:aws:iam::012345678901:mfa/ec2-user',
+          comment: 'arn:aws:iam::747118721026:mfa/ec2-user',
           updated_at: Time.parse('2016-12-01T22:20:01Z')
         },
         password: 'biglongbase64'
@@ -240,7 +240,7 @@ describe Awskeyring do
         Keychain::Item,
         attributes: {
           label: 'session-key test',
-          account: 'ASIATESTTEST',
+          account: 'ASIA234567ABCTESTHIJ',
           comment: 'role role',
           updated_at: Time.parse('2016-12-01T22:20:01Z')
         },
@@ -290,7 +290,7 @@ describe Awskeyring do
       end.to output(/# Using temporary session credentials/).to_stdout
       expect(test_hash).to eq(
         account: 'test',
-        key: 'ASIATESTTEST',
+        key: 'ASIA234567ABCTESTHIJ',
         secret: 'bigerlongbase64',
         token: 'evenlongerbase64token',
         expiry: Time.parse('2016-12-20T22:20:01Z').to_i,
@@ -306,14 +306,14 @@ describe Awskeyring do
         secret: 'biglongbase64',
         token: nil,
         expiry: nil,
-        mfa: 'arn:aws:iam::012345678901:mfa/ec2-user',
+        mfa: 'arn:aws:iam::747118721026:mfa/ec2-user',
         updated: Time.parse('2016-12-01T22:20:01Z')
       )
     end
 
     it 'returns a hash with the role' do
       expect(awskeyring.get_role_arn(role_name: 'role')).to eq(
-        'arn:aws:iam::012345678901:role/test'
+        'arn:aws:iam::747118721026:role/test'
       )
     end
 
@@ -348,6 +348,12 @@ describe Awskeyring do
     it 'lists all accounts' do
       expect(awskeyring.list_account_names).to eq(
         ['test']
+      )
+    end
+
+    it 'lists all accounts with detail' do
+      expect(awskeyring.list_account_names_plus).to eq(
+        ["test\t747118721026"]
       )
     end
 
@@ -389,20 +395,20 @@ describe Awskeyring do
 
     it 'lists all roles with detail' do
       expect(awskeyring.list_role_names_plus).to eq(
-        ["role\tarn:aws:iam::012345678901:role/test"]
+        ["role\tarn:aws:iam::747118721026:role/test"]
       )
     end
   end
 
   context 'when there is an expired token' do
-    let(:access_key) { 'AKIA1234567890ABCDEF' }
+    let(:access_key) { 'AKIA234567ABCDEFGHIJ' }
     let(:item) do
       instance_double(
         Keychain::Item,
         attributes: {
           label: 'account test',
           account: access_key,
-          comment: 'arn:aws:iam::012345678901:mfa/ec2-user',
+          comment: 'arn:aws:iam::747118721026:mfa/ec2-user',
           updated_at: Time.parse('2016-12-01T22:20:01Z')
         },
         password: 'biglongbase64'
@@ -413,7 +419,7 @@ describe Awskeyring do
         Keychain::Item,
         attributes: {
           label: 'session-key test',
-          account: 'ASIATESTTEST',
+          account: 'ASIA234567ABCTESTHIJ',
           comment: 'role role',
           updated_at: Time.parse('2016-12-01T22:20:01Z')
         },
@@ -462,7 +468,7 @@ describe Awskeyring do
       end.to output(/# Removing expired session credentials/).to_stdout
       expect(test_hash).to eq(
         account: 'test',
-        key: 'AKIA1234567890ABCDEF',
+        key: 'AKIA234567ABCDEFGHIJ',
         secret: 'biglongbase64',
         token: nil,
         expiry: nil,


### PR DESCRIPTION
# Description

New Feature! adds the ability to decode the account number from access keys and will add a new env var AWS_ACCOUNT_ID to `exec` and `env` commands, also adds a `decode` command that I may remove later depending on how I feel. Caveat AWS may change how the account number is encoded in the future so its more of a guess.

To test run `awskeyring decode AKIA.....`(what ever your access key is) and see if you get the correct account number matching `aws sts get-caller-identity`.

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
