### PR TITLE
Generate fake creds for testing.

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -33,6 +33,7 @@ en:
     notoken: 'Do not use saved token.'
     noremote: 'Do not validate with remote api.'
     path: 'The service PATH to open.'
+    test: 'Generate test credentials.'
     browser: 'Specify an alternative browser.'
     secret: 'AWS account secret.'
     unset: 'Unset environment variables.'

--- a/lib/awskeyring/awsapi.rb
+++ b/lib/awskeyring/awsapi.rb
@@ -3,6 +3,7 @@
 require 'aws-sdk-iam'
 require 'cgi'
 require 'json'
+require 'securerandom'
 
 # Awskeyring Module,
 # gives you an interface to access keychains and items.
@@ -176,6 +177,23 @@ module Awskeyring
         secret: creds.credentials.secret_access_key,
         token: creds.credentials.session_token,
         expiry: Time.new + TWELVE_HOUR,
+        role: nil
+      }
+    end
+
+    # Generate test credentials for AWS
+    #
+    # @return [Hash] with the new credentials
+    #    key The aws_access_key_id
+    #    secret The aws_secret_access_key
+    #    expiry expiry time
+    def self.gen_test_credentials(account:)
+      {
+        account: account,
+        key: "AKIA#{Array.new(16) { [*'A'..'Z', *'2'..'7'].sample }.join}",
+        secret: SecureRandom.base64(30),
+        token: nil,
+        expiry: nil,
         role: nil
       }
     end

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "June 2024" "" ""
+.TH "AWSKEYRING" "5" "January 2025" "" ""
 .
 .SH "NAME"
 \fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain
@@ -95,7 +95,10 @@ Outputs bourne shell environment exports for an ACCOUNT
 \-n, \-\-no\-token: Do not use saved token\.
 .
 .br
-\-u, \-\-unset, \-\-no\-unset: Unset environment variables\.
+\-t, \-\-test: Generate test credentials\.
+.
+.br
+\-u, \-\-unset: Unset environment variables\.
 .
 .TP
 exec ACCOUNT command\.\.\.:
@@ -152,6 +155,9 @@ Outputs AWS CLI compatible JSON for an ACCOUNT
 .
 .br
 \-n, \-\-no\-token: Do not use saved token\.
+.
+.br
+\-t, \-\-test: Generate test credentials\.
 .
 .TP
 list:

--- a/man/awskeyring.5.ronn
+++ b/man/awskeyring.5.ronn
@@ -50,7 +50,8 @@ The commands are as follows:
 
     -f, --force: Force output to a tty.<br>
     -n, --no-token: Do not use saved token.<br>
-    -u, --unset, --no-unset: Unset environment variables.
+    -t, --test: Generate test credentials.<br>
+    -u, --unset: Unset environment variables.
 
 * exec ACCOUNT command...:
 
@@ -80,7 +81,8 @@ The commands are as follows:
     Outputs AWS CLI compatible JSON for an ACCOUNT<br>
 
     -f, --force:    Force output to a tty.<br>
-    -n, --no-token: Do not use saved token.
+    -n, --no-token: Do not use saved token.<br>
+    -t, --test: Generate test credentials.
 
 * list:
 

--- a/spec/lib/awskeyring/awsapi_spec.rb
+++ b/spec/lib/awskeyring/awsapi_spec.rb
@@ -536,5 +536,11 @@ describe Awskeyring::Awsapi do
     it 'calls get_account_id with an invalid token' do
       expect(awsapi.get_account_id(key: key)).to eq('000000000000')
     end
+
+    it 'generates test credentials' do
+      creds = awsapi.gen_test_credentials(account: 'testaccount')
+      expect { Awskeyring::Validate.access_key(creds[:key]) }.not_to raise_error
+      expect { Awskeyring::Validate.secret_access_key(creds[:secret]) }.not_to raise_error
+    end
   end
 end

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -169,7 +169,7 @@ describe AwskeyringCommand do
       ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
       allow(ARGF).to receive(:argv).and_return(['awskeyring', '--', 'test'])
       expect { described_class.start(%w[autocomplete test]) }
-        .to output(/--force\n--no-token\n--unset/).to_stdout
+        .to output(/--force\n--no-token\n--test\n--unset/).to_stdout
       ENV['COMP_LINE'] = nil
     end
 
@@ -243,6 +243,12 @@ unset AWS_SECRET_KEY
 unset AWS_SECURITY_TOKEN
 unset AWS_SESSION_TOKEN
 )).to_stdout
+      expect(Awskeyring).not_to have_received(:get_valid_creds)
+    end
+
+    it 'export a fake AWS Access key' do
+      expect { described_class.start(%w[env test --test]) }
+        .to output(/export AWS_DEFAULT_REGION="us-east-1"/).to_stdout
       expect(Awskeyring).not_to have_received(:get_valid_creds)
     end
   end
@@ -348,6 +354,12 @@ unset AWS_SESSION_TOKEN
         )}\n").to_stdout
       expect(Awskeyring).to have_received(:account_exists).with('test')
       expect(Awskeyring).to have_received(:get_valid_creds).with(account: 'test', no_token: false)
+    end
+
+    it 'provides a test account via JSON' do
+      expect { described_class.start(%w[json test --test]) }
+        .to output(/  "Version": 1,/).to_stdout
+      expect(Awskeyring).not_to have_received(:get_valid_creds).with(account: 'test', no_token: false)
     end
 
     it 'runs an external command' do


### PR DESCRIPTION
# Description

Adds a new `--test` flag to enable the creation of test (fake) AWS credentials. Useful for testing and non AWS systems that use a similar format ([minio](https://github.com/minio/minio/), [local-kms](https://github.com/nsmithuk/local-kms) and [dynalite](https://github.com/architect/dynalite) for example).

## Did you run the Tests?

- [X] Rubocop
- [X] Rspec
- [x] Filemode
- [x] Yard
